### PR TITLE
Day change logic

### DIFF
--- a/apps/nextjs/src/app/_components/ExpensesPage/ExpensesDialog.tsx
+++ b/apps/nextjs/src/app/_components/ExpensesPage/ExpensesDialog.tsx
@@ -35,7 +35,7 @@ import {
 import { Textarea } from "@acme/ui/textarea";
 
 import formatMoneyInput from "~/utils/formatMoneyInput";
-import DatePicker from "./DatePicker";
+import DatePicker from "../DatePicker";
 
 const formSchema = z.object({
   date: z.date(),

--- a/apps/nextjs/src/app/_components/TimePage/DayPagination.tsx
+++ b/apps/nextjs/src/app/_components/TimePage/DayPagination.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@acme/ui";
+import { buttonVariants } from "@acme/ui/button";
 import {
   Pagination,
   PaginationContent,
@@ -14,13 +16,13 @@ const DayPagination = ({ selectedDate }: { selectedDate: Date }) => {
       <PaginationContent>
         <PaginationItem>
           <PaginationPrevious
-            className="p-2"
+            className={cn(buttonVariants({ variant: "outline" }), "p-2")}
             href={`/time/${getDateSlug(getPrevDay(selectedDate))}`}
           />
         </PaginationItem>
         <PaginationItem>
           <PaginationNext
-            className="p-2"
+            className={cn(buttonVariants({ variant: "outline" }), "p-2")}
             href={`/time/${getDateSlug(getNextDay(selectedDate))}`}
           />
         </PaginationItem>

--- a/apps/nextjs/src/app/_components/TimePage/DayPagination.tsx
+++ b/apps/nextjs/src/app/_components/TimePage/DayPagination.tsx
@@ -1,0 +1,32 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+} from "@acme/ui/pagination";
+
+import { getDateSlug, getNextDay, getPrevDay } from "~/utils";
+
+const DayPagination = ({ selectedDate }: { selectedDate: Date }) => {
+  return (
+    <Pagination className="m-0 w-fit">
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            className="p-2"
+            href={`/time/${getDateSlug(getPrevDay(selectedDate))}`}
+          />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext
+            className="p-2"
+            href={`/time/${getDateSlug(getNextDay(selectedDate))}`}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+};
+
+export default DayPagination;

--- a/apps/nextjs/src/app/_components/TimePage/DayTabs.tsx
+++ b/apps/nextjs/src/app/_components/TimePage/DayTabs.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { RouterOutputs } from "@acme/api";
+import { Button } from "@acme/ui/button";
+import { Separator } from "@acme/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@acme/ui/tabs";
+
+import {
+  areSameDates,
+  converMinutesToHours,
+  currentWeekDates,
+  getDateSlug,
+  getShortDay,
+} from "~/utils";
+import TrackerDialog from "../../_components/TimePage/TrackerDialog";
+
+const DayTabs = ({
+  currentWeekEntriesData,
+  currentDayEntries,
+  selectedDayIdx,
+}: {
+  currentWeekEntriesData: RouterOutputs["timeEntries"]["getUserTimeEntries"];
+  currentDayEntries: RouterOutputs["timeEntries"]["getUserTimeEntries"];
+  selectedDayIdx: number;
+}) => {
+  const router = useRouter();
+
+  const onTabChange = (newDayIdx: string) => {
+    const selectedDate = currentWeekDates[Number(newDayIdx)];
+    if (!selectedDate) throw new Error("Invalid day index");
+    router.push(`/time/${getDateSlug(selectedDate)}`);
+  };
+  return (
+    <Tabs
+      onValueChange={onTabChange}
+      value={selectedDayIdx.toString()}
+      className="relative mr-auto w-full"
+    >
+      <div className="flex items-center justify-between pb-3">
+        <TabsList className="w-full justify-start gap-6 rounded-none border-b bg-transparent p-0">
+          {currentWeekDates.map((day, idx) => (
+            <TabsTrigger
+              key={idx}
+              value={idx.toString()}
+              className="relative mb-2 flex w-24 flex-col items-start rounded-none border-b-2 border-b-transparent bg-transparent px-0 font-semibold text-muted-foreground shadow-none transition-none data-[state=active]:border-b-primary data-[state=active]:text-foreground data-[state=active]:shadow-none"
+            >
+              <span>{getShortDay(day)}</span>
+              <span className="text-xs">
+                {currentWeekEntriesData?.find((item) =>
+                  areSameDates(item.date, day),
+                )?.timeInMinutes
+                  ? converMinutesToHours(
+                      currentWeekEntriesData.find((item) =>
+                        areSameDates(item.date, day),
+                      )!.timeInMinutes!,
+                    )
+                  : "00:00"}
+              </span>
+            </TabsTrigger>
+          ))}
+          <TabsTrigger
+            value="total"
+            disabled
+            className="relative mb-2 ml-auto flex w-24 flex-col items-end rounded-none border-b-2 border-b-transparent bg-transparent px-0 font-semibold text-muted-foreground shadow-none transition-none data-[state=active]:border-b-primary data-[state=active]:text-foreground data-[state=active]:shadow-none"
+          >
+            <span>{"Week total"}</span>
+            <span className="text-xs">
+              {currentWeekEntriesData
+                ? converMinutesToHours(
+                    currentWeekEntriesData
+                      .map((item) => item.timeInMinutes)
+                      .reduce((prev, cur) => prev + cur, 0),
+                  )
+                : "00:00"}
+            </span>
+          </TabsTrigger>
+        </TabsList>
+      </div>
+      <TabsContent
+        value={selectedDayIdx.toString()}
+        className="relative rounded-md border"
+      >
+        {currentDayEntries?.length ? (
+          <div className="flex flex-col gap-4">
+            <ul className="flex flex-col">
+              {currentDayEntries.map((item) => (
+                <li key={item.id}>
+                  <div className="flex justify-between p-4">
+                    <div className="flex flex-col gap-1">
+                      <span className="font-bold">
+                        {item.projectCategory.name}
+                      </span>
+                      <span className="text-sm">
+                        {item.projectCategory.project.name}
+                      </span>
+                      <span className="text-xs">{item.notes}</span>
+                    </div>
+                    <div className="flex items-center gap-4">
+                      <span>0:00</span>
+                      <Button>Edit</Button>
+                    </div>
+                  </div>
+                  <Separator />
+                </li>
+              ))}
+            </ul>
+            <TrackerDialog>
+              <Button
+                className="mx-auto mb-4 h-12 w-full max-w-44 text-3xl"
+                variant="outline"
+              >
+                +
+              </Button>
+            </TrackerDialog>
+          </div>
+        ) : (
+          <TrackerDialog>
+            <Button
+              className="flex h-80 w-full flex-col gap-4"
+              variant="outline"
+            >
+              <span className="text-3xl">No time tracked today</span>
+              <span>Click to add your first record</span>
+            </Button>
+          </TrackerDialog>
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+};
+
+export default DayTabs;

--- a/apps/nextjs/src/app/_components/TimePage/DayTabs.tsx
+++ b/apps/nextjs/src/app/_components/TimePage/DayTabs.tsx
@@ -11,7 +11,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@acme/ui/tabs";
 import {
   areSameDates,
   converMinutesToHours,
-  currentWeekDates,
   getDateSlug,
   getShortDay,
   getWeekBoundaries,
@@ -36,10 +35,14 @@ const DayTabs = ({
   const currentWeekDates = useMemo(() => {
     const parsedDate = parseDateFromParams(params.slug);
 
-    const weekBoundaries = getWeekBoundaries(parsedDate);
+    if (parsedDate) {
+      const weekBoundaries = getWeekBoundaries(parsedDate);
 
-    return getWeekDates(weekBoundaries.startDate, weekBoundaries.endDate);
+      return getWeekDates(weekBoundaries.startDate, weekBoundaries.endDate);
+    }
   }, [params]);
+
+  if (!currentWeekDates) return null;
 
   const onTabChange = (newDayIdx: string) => {
     const selectedDate = currentWeekDates[Number(newDayIdx)];

--- a/apps/nextjs/src/app/_components/TimePage/DayTabs.tsx
+++ b/apps/nextjs/src/app/_components/TimePage/DayTabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useMemo } from "react";
+import { useParams, useRouter } from "next/navigation";
 
 import { RouterOutputs } from "@acme/api";
 import { Button } from "@acme/ui/button";
@@ -13,6 +14,9 @@ import {
   currentWeekDates,
   getDateSlug,
   getShortDay,
+  getWeekBoundaries,
+  getWeekDates,
+  parseDateFromParams,
 } from "~/utils";
 import TrackerDialog from "../../_components/TimePage/TrackerDialog";
 
@@ -27,11 +31,22 @@ const DayTabs = ({
 }) => {
   const router = useRouter();
 
+  const params = useParams() as { slug: string[] };
+
+  const currentWeekDates = useMemo(() => {
+    const parsedDate = parseDateFromParams(params.slug);
+
+    const weekBoundaries = getWeekBoundaries(parsedDate);
+
+    return getWeekDates(weekBoundaries.startDate, weekBoundaries.endDate);
+  }, [params]);
+
   const onTabChange = (newDayIdx: string) => {
     const selectedDate = currentWeekDates[Number(newDayIdx)];
     if (!selectedDate) throw new Error("Invalid day index");
     router.push(`/time/${getDateSlug(selectedDate)}`);
   };
+
   return (
     <Tabs
       onValueChange={onTabChange}
@@ -48,7 +63,7 @@ const DayTabs = ({
             >
               <span>{getShortDay(day)}</span>
               <span className="text-xs">
-                {currentWeekEntriesData?.find((item) =>
+                {currentWeekEntriesData.find((item) =>
                   areSameDates(item.date, day),
                 )?.timeInMinutes
                   ? converMinutesToHours(

--- a/apps/nextjs/src/app/_components/TimePage/SelectedDateContext.tsx
+++ b/apps/nextjs/src/app/_components/TimePage/SelectedDateContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+
+type SelectedDateContextValue = {
+  selectedDate: Date;
+  idx: number;
+};
+export const SelectedDateContext =
+  createContext<SelectedDateContextValue | null>(null);
+
+export const useSelectedDateContext = () => {
+  const context = useContext(SelectedDateContext);
+  if (!context) {
+    throw new Error(
+      "useSelectedDateContext must be used within a SelectedDateProvider",
+    );
+  }
+  return context;
+};

--- a/apps/nextjs/src/app/_components/TimePage/TrackerDialog.tsx
+++ b/apps/nextjs/src/app/_components/TimePage/TrackerDialog.tsx
@@ -32,8 +32,7 @@ import {
 } from "@acme/ui/select";
 import { Textarea } from "@acme/ui/textarea";
 
-import { api } from "../../trpc/react";
-import { useSelectedDateContext } from "../time/[[...slug]]/page";
+import { api } from "../../../trpc/react";
 
 const formSchema = z.object({
   projectId: z.string(),
@@ -60,7 +59,6 @@ const TrackerDialog = ({ children }: { children: ReactNode }) => {
   const closeForm = () => {
     setIsFormOpen(false);
   };
-  const { weekBoundaries } = useSelectedDateContext();
 
   const onSubmit: SubmitHandler<z.infer<typeof formSchema>> = async (
     values,
@@ -72,10 +70,10 @@ const TrackerDialog = ({ children }: { children: ReactNode }) => {
       projectCategoryId: values.projectCategoryId,
       timeInMinutes: values.timeInMinutes,
     });
-    // timeEntriesQueryCache.invalidate({
-    //   from: weekBoundaries.startDate,
-    //   to: weekBoundaries.endDate,
-    // })
+    /* timeEntriesQueryCache.invalidate({
+       from: currentWeekBoundaries.startDate,
+       to: currentWeekBoundaries.endDate,
+     }) */
     closeForm();
   };
 

--- a/apps/nextjs/src/app/expenses/page.tsx
+++ b/apps/nextjs/src/app/expenses/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@acme/ui/table";
 
 import formatMoneyInput from "~/utils/formatMoneyInput";
-import ExpensesDialog from "../_components/ExpensesDialog";
+import ExpensesDialog from "../_components/ExpensesPage/ExpensesDialog";
 import Clip from "../_components/Icons/Clip";
 
 const invoices = [

--- a/apps/nextjs/src/app/time/[[...slug]]/page.tsx
+++ b/apps/nextjs/src/app/time/[[...slug]]/page.tsx
@@ -7,9 +7,9 @@ import DayTabs from "~/app/_components/TimePage/DayTabs";
 import { api } from "~/trpc/server";
 import {
   areSameDates,
-  currentWeekBoundaries,
-  currentWeekDates,
   getDateSlug,
+  getWeekBoundaries,
+  getWeekDates,
   parseDateFromParams,
 } from "~/utils";
 
@@ -33,14 +33,21 @@ export default async function TimePage({
 }: {
   params: { slug: string[] | undefined };
 }) {
+  const parsedDate = parseDateFromParams(params.slug);
+  if (!parsedDate) notFound();
+
+  const currentWeekBoundaries = getWeekBoundaries(parsedDate);
+
+  const currentWeekDates = getWeekDates(
+    currentWeekBoundaries.startDate,
+    currentWeekBoundaries.endDate,
+  );
+
   const currentWeekEntries = await api.timeEntries.getUserTimeEntries({
     from: currentWeekBoundaries.startDate,
     to: currentWeekBoundaries.endDate,
   });
 
-  const parsedDate = parseDateFromParams(params.slug);
-
-  if (!parsedDate) notFound();
   const selectedDay = {
     date: parsedDate,
     idx: getDayIndex(currentWeekDates, parsedDate),

--- a/apps/nextjs/src/app/time/[[...slug]]/page.tsx
+++ b/apps/nextjs/src/app/time/[[...slug]]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense, useMemo } from "react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -9,6 +10,7 @@ import {
   currentWeekBoundaries,
   currentWeekDates,
   getDateSlug,
+  parseDateFromParams,
 } from "~/utils";
 
 function getDayIndex(weekDates: Date[], currentDate: Date) {
@@ -26,15 +28,10 @@ function getFullDay(date: Date) {
   return formatter.format(date);
 }
 
-function parseDateFromParams(params: string[]) {
-  const joinedParams = params.join("/");
-  return joinedParams === "" ? new Date() : new Date(Date.parse(joinedParams));
-}
-
 export default async function TimePage({
   params,
 }: {
-  params: { slug: string[] };
+  params: { slug: string[] | undefined };
 }) {
   const currentWeekEntries = await api.timeEntries.getUserTimeEntries({
     from: currentWeekBoundaries.startDate,
@@ -49,8 +46,8 @@ export default async function TimePage({
     idx: getDayIndex(currentWeekDates, parsedDate),
   };
 
-  const currentDayEntries = currentWeekEntries.filter(
-    (entry) => entry.date.getDay() === selectedDay.date.getDay(),
+  const currentDayEntries = currentWeekEntries.filter((entry) =>
+    areSameDates(entry.date, selectedDay.date),
   );
   const isSelectedACurrentDate = areSameDates(selectedDay.date, new Date());
 

--- a/apps/nextjs/src/app/time/[[...slug]]/page.tsx
+++ b/apps/nextjs/src/app/time/[[...slug]]/page.tsx
@@ -1,78 +1,20 @@
-"use client";
-
-import { createContext, useContext, useMemo, useState } from "react";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
-import { Button } from "@acme/ui/button";
+import DayPagination from "~/app/_components/TimePage/DayPagination";
+import DayTabs from "~/app/_components/TimePage/DayTabs";
+import { api } from "~/trpc/server";
 import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@acme/ui/pagination";
-import { Separator } from "@acme/ui/separator";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@acme/ui/tabs";
-
-import TrackerDialog from "../../_components/TrackerDialog";
-import { api } from "../../../trpc/react";
-
-function getWeekBoundaries(date: Date) {
-  // Calculate start date of the week (Monday)
-  let startDate = new Date(date);
-  startDate.setDate(date.getDate() - ((date.getDay() + 6) % 7));
-
-  // Set hours, minutes, seconds, and milliseconds to 0
-  startDate.setHours(0);
-  startDate.setMinutes(0);
-  startDate.setSeconds(0);
-  startDate.setMilliseconds(0);
-
-  // Calculate end date of the week (Sunday)
-  let endDate = new Date(startDate);
-  endDate.setDate(startDate.getDate() + 6);
-
-  // Set hours to 23, minutes to 59, seconds to 59
-  endDate.setHours(23);
-  endDate.setMinutes(59);
-  endDate.setSeconds(59);
-
-  return { startDate, endDate };
-}
-
-function areSameDates(date1: Date, date2: Date) {
-  return (
-    date1.getFullYear() === date2.getFullYear() &&
-    date1.getMonth() === date2.getMonth() &&
-    date1.getDate() === date2.getDate()
-  );
-}
-
-function getWeekDates(startDate: Date, endDate: Date) {
-  let dates = [];
-  let currentDate = new Date(startDate);
-
-  while (currentDate <= endDate) {
-    dates.push(new Date(currentDate));
-    currentDate.setDate(currentDate.getDate() + 1);
-  }
-
-  return dates;
-}
+  areSameDates,
+  currentWeekBoundaries,
+  currentWeekDates,
+  getDateSlug,
+} from "~/utils";
 
 function getDayIndex(weekDates: Date[], currentDate: Date) {
   const currentDay = currentDate.getDay();
   const dayIndex = weekDates.findIndex((date) => date.getDay() === currentDay);
   return dayIndex;
-}
-
-function getShortDay(date: Date) {
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    weekday: "short",
-  });
-  return formatter.format(date);
 }
 
 function getFullDay(date: Date) {
@@ -84,176 +26,58 @@ function getFullDay(date: Date) {
   return formatter.format(date);
 }
 
-type SelectedDateContextValue = {
-  selectedDate: Date;
-  weekBoundaries: { startDate: Date; endDate: Date };
-};
-const selectedDateContext = createContext<SelectedDateContextValue | null>(
-  null,
-);
+function parseDateFromParams(params: string[]) {
+  const joinedParams = params.join("/");
+  return joinedParams === "" ? new Date() : new Date(Date.parse(joinedParams));
+}
 
-export const useSelectedDateContext = () => {
-  const context = useContext(selectedDateContext);
-  if (!context) {
-    throw new Error(
-      "useSelectedDateContext must be used within a SelectedDateProvider",
-    );
-  }
-  return context;
-};
-
-export default function TimePage() {
-  const currentWeekBoundaries = useMemo(() => {
-    const currentDate = new Date();
-    return getWeekBoundaries(currentDate);
-  }, []);
-
-  const currentWeekDates = useMemo(() => {
-    return getWeekDates(
-      currentWeekBoundaries.startDate,
-      currentWeekBoundaries.endDate,
-    );
-  }, []);
-
-  const currentWeekEntriesQuery = api.timeEntries.getUserTimeEntries.useQuery({
+export default async function TimePage({
+  params,
+}: {
+  params: { slug: string[] };
+}) {
+  const currentWeekEntries = await api.timeEntries.getUserTimeEntries({
     from: currentWeekBoundaries.startDate,
     to: currentWeekBoundaries.endDate,
   });
 
-  const [selectedDay, setSelectedDay] = useState<{ date: Date; idx: number }>(
-    () => {
-      const today = new Date();
-      return {
-        date: today,
-        idx: getDayIndex(currentWeekDates, today),
-      };
-    },
-  );
+  const parsedDate = parseDateFromParams(params.slug);
 
-  const currentDayEntries = useMemo(() => {
-    const entries = currentWeekEntriesQuery.data?.filter(
-      (entry) => entry.date.getDay() === selectedDay.date.getDay(),
-    );
-    return entries;
-  }, [selectedDay.date, currentWeekEntriesQuery]);
-
-  const currentDayIndex = useMemo(() => {
-    return getDayIndex(currentWeekDates, new Date());
-  }, []);
-
-  const onTabChange = (newDayIdx: string) => {
-    const selectedDate = currentWeekDates[Number(newDayIdx)];
-    if (!selectedDate) {
-      throw new Error("Invalid day index");
-    }
-    setSelectedDay({ date: selectedDate, idx: Number(newDayIdx) });
+  if (!parsedDate) notFound();
+  const selectedDay = {
+    date: parsedDate,
+    idx: getDayIndex(currentWeekDates, parsedDate),
   };
 
+  const currentDayEntries = currentWeekEntries.filter(
+    (entry) => entry.date.getDay() === selectedDay.date.getDay(),
+  );
+  const isSelectedACurrentDate = areSameDates(selectedDay.date, new Date());
+
   return (
-    <selectedDateContext.Provider
-      value={{
-        selectedDate: selectedDay.date,
-        weekBoundaries: currentWeekBoundaries,
-      }}
-    >
+    <>
       <div className="mb-10 flex items-center gap-4">
-        <Pagination className="m-0 w-fit">
-          <PaginationContent>
-            <PaginationItem>
-              <PaginationPrevious className="p-2" href="#" />
-            </PaginationItem>
-            <PaginationItem>
-              <PaginationNext className="p-2" href="#" />
-            </PaginationItem>
-          </PaginationContent>
-        </Pagination>
-        <h1 className="text-3xl font-semibold">
+        <DayPagination selectedDate={selectedDay.date} />
+        <h1 className={"text-3xl font-semibold"}>
+          {isSelectedACurrentDate && (
+            <span className="font-extrabold">Today: </span>
+          )}
           {getFullDay(selectedDay.date)}
         </h1>
-        {!areSameDates(selectedDay.date, new Date()) && (
-          <Link className="underline underline-offset-4" href={"#"}>
+        {!isSelectedACurrentDate && (
+          <Link
+            className="underline underline-offset-4"
+            href={`/time/${getDateSlug(new Date())}`}
+          >
             Return to today
           </Link>
         )}
       </div>
-      <Tabs
-        defaultValue={currentDayIndex.toString()}
-        onValueChange={onTabChange}
-        value={selectedDay.idx.toString()}
-        className="relative mr-auto w-full"
-      >
-        <div className="flex items-center justify-between pb-3">
-          <TabsList className="w-full justify-start gap-6 rounded-none border-b bg-transparent p-0">
-            {currentWeekDates.map((day, idx) => (
-              <TabsTrigger
-                key={idx}
-                value={idx.toString()}
-                className="relative mb-2 flex w-24 flex-col items-start rounded-none border-b-2 border-b-transparent bg-transparent px-0 font-semibold text-muted-foreground shadow-none transition-none data-[state=active]:border-b-primary data-[state=active]:text-foreground data-[state=active]:shadow-none"
-              >
-                <span>{getShortDay(day)}</span>
-                <span className="text-xs">0:00</span>
-              </TabsTrigger>
-            ))}
-            <TabsTrigger
-              value="total"
-              disabled
-              className="relative mb-2 ml-auto flex w-24 flex-col items-end rounded-none border-b-2 border-b-transparent bg-transparent px-0 font-semibold text-muted-foreground shadow-none transition-none data-[state=active]:border-b-primary data-[state=active]:text-foreground data-[state=active]:shadow-none"
-            >
-              <span>{"Week total"}</span>
-              <span className="text-xs">0:00</span>
-            </TabsTrigger>
-          </TabsList>
-        </div>
-        <TabsContent
-          value={selectedDay.idx.toString()}
-          className="relative rounded-md border"
-        >
-          {currentDayEntries?.length ? (
-            <div className="flex flex-col gap-4">
-              <ul className="flex flex-col">
-                {currentDayEntries.map((item) => (
-                  <li>
-                    <div className="flex justify-between p-4">
-                      <div className="flex flex-col gap-1">
-                        <span className="font-bold">
-                          {item.projectCategory.name}
-                        </span>
-                        <span className="text-sm">
-                          {item.projectCategory.project.name}
-                        </span>
-                        <span className="text-xs">{item.notes}</span>
-                      </div>
-                      <div className="flex items-center gap-4">
-                        <span>0:00</span>
-                        <Button>Edit</Button>
-                      </div>
-                    </div>
-                    <Separator />
-                  </li>
-                ))}
-              </ul>
-              <TrackerDialog>
-                <Button
-                  className="mx-auto mb-4 h-12 w-full max-w-44 text-3xl"
-                  variant="outline"
-                >
-                  +
-                </Button>
-              </TrackerDialog>
-            </div>
-          ) : (
-            <TrackerDialog>
-              <Button
-                className="flex h-80 w-full flex-col gap-4"
-                variant="outline"
-              >
-                <span className="text-3xl">No time tracked today</span>
-                <span>Click to add your first record</span>
-              </Button>
-            </TrackerDialog>
-          )}
-        </TabsContent>
-      </Tabs>
-    </selectedDateContext.Provider>
+      <DayTabs
+        currentWeekEntriesData={currentWeekEntries}
+        currentDayEntries={currentDayEntries}
+        selectedDayIdx={selectedDay.idx}
+      />
+    </>
   );
 }

--- a/apps/nextjs/src/utils/index.ts
+++ b/apps/nextjs/src/utils/index.ts
@@ -1,0 +1,82 @@
+export function areSameDates(date1: Date, date2: Date) {
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+}
+
+export function getShortDay(date: Date) {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+  });
+  return formatter.format(date);
+}
+
+export function getDateSlug(date: Date) {
+  return `/${new Intl.DateTimeFormat("en-US").format(date)}`;
+}
+
+export function getPrevDay(date: Date) {
+  const prevDay = new Date(date);
+  prevDay.setDate(date.getDate() - 1);
+  return prevDay;
+}
+
+export function getNextDay(date: Date) {
+  const nextDay = new Date(date);
+  nextDay.setDate(date.getDate() + 1);
+  return nextDay;
+}
+
+export const converMinutesToHours = (totalMinutes: number) => {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  return `${padToTwoDigits(hours)}:${padToTwoDigits(minutes)}`;
+};
+
+export const currentWeekBoundaries = getWeekBoundaries(new Date());
+
+function padToTwoDigits(num: number) {
+  return num.toString().padStart(2, "0");
+}
+export const currentWeekDates = getWeekDates(
+  currentWeekBoundaries.startDate,
+  currentWeekBoundaries.endDate,
+);
+
+function getWeekDates(startDate: Date, endDate: Date) {
+  let dates = [];
+  let currentDate = new Date(startDate);
+
+  while (currentDate <= endDate) {
+    dates.push(new Date(currentDate));
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  return dates;
+}
+
+function getWeekBoundaries(date: Date) {
+  // Calculate start date of the week (Monday)
+  let startDate = new Date(date);
+  startDate.setDate(date.getDate() - ((date.getDay() + 6) % 7));
+
+  // Set hours, minutes, seconds, and milliseconds to 0
+  startDate.setHours(0);
+  startDate.setMinutes(0);
+  startDate.setSeconds(0);
+  startDate.setMilliseconds(0);
+
+  // Calculate end date of the week (Sunday)
+  let endDate = new Date(startDate);
+  endDate.setDate(startDate.getDate() + 6);
+
+  // Set hours to 23, minutes to 59, seconds to 59
+  endDate.setHours(23);
+  endDate.setMinutes(59);
+  endDate.setSeconds(59);
+
+  return { startDate, endDate };
+}

--- a/apps/nextjs/src/utils/index.ts
+++ b/apps/nextjs/src/utils/index.ts
@@ -6,6 +6,10 @@ export function areSameDates(date1: Date, date2: Date) {
   );
 }
 
+export function parseDateFromParams(params: string[] | undefined) {
+  return !params ? new Date() : new Date(Date.parse(params.join("/")));
+}
+
 export function getShortDay(date: Date) {
   const formatter = new Intl.DateTimeFormat("en-US", {
     weekday: "short",
@@ -46,7 +50,7 @@ export const currentWeekDates = getWeekDates(
   currentWeekBoundaries.endDate,
 );
 
-function getWeekDates(startDate: Date, endDate: Date) {
+export function getWeekDates(startDate: Date, endDate: Date) {
   let dates = [];
   let currentDate = new Date(startDate);
 
@@ -58,7 +62,7 @@ function getWeekDates(startDate: Date, endDate: Date) {
   return dates;
 }
 
-function getWeekBoundaries(date: Date) {
+export function getWeekBoundaries(date: Date) {
   // Calculate start date of the week (Monday)
   let startDate = new Date(date);
   startDate.setDate(date.getDate() - ((date.getDay() + 6) % 7));

--- a/apps/nextjs/src/utils/index.ts
+++ b/apps/nextjs/src/utils/index.ts
@@ -7,7 +7,10 @@ export function areSameDates(date1: Date, date2: Date) {
 }
 
 export function parseDateFromParams(params: string[] | undefined) {
-  return !params ? new Date() : new Date(Date.parse(params.join("/")));
+  if (!params) return new Date();
+
+  const parsedDate = new Date(Date.parse(params.join("/")));
+  if (!isNaN(parsedDate.getTime())) return parsedDate;
 }
 
 export function getShortDay(date: Date) {
@@ -40,15 +43,9 @@ export const converMinutesToHours = (totalMinutes: number) => {
   return `${padToTwoDigits(hours)}:${padToTwoDigits(minutes)}`;
 };
 
-export const currentWeekBoundaries = getWeekBoundaries(new Date());
-
 function padToTwoDigits(num: number) {
   return num.toString().padStart(2, "0");
 }
-export const currentWeekDates = getWeekDates(
-  currentWeekBoundaries.startDate,
-  currentWeekBoundaries.endDate,
-);
 
 export function getWeekDates(startDate: Date, endDate: Date) {
   let dates = [];


### PR DESCRIPTION
Added logic that current day (and week boundaries) are based on url query
Separated client and  server components, so Time page is server component now.
Added logic to change days with arrows, so now we can go to other weeks

was forced to remove useContext. since it it not working in server components. + don't see much use for it here tbh. I haven't deleted ur functions tho, so if you want to bring it back we will just make a client wrapper for the context

P.S. Moved all the util fucntions for date manipulations to util folder. will need to separte to different files.

P.P.S. there is a big duplication of weekBoundaries calculation on page level and in tabs component. If you gonna work on the project before i get back to it please refacrore it. i think we can make a hook or smth for it